### PR TITLE
make watchdog.stop idempotent

### DIFF
--- a/test/started.lua
+++ b/test/started.lua
@@ -15,4 +15,5 @@ fiber.sleep(2)
 local t1 = clock.monotonic()
 log.info("Still alive after %f sec", t1-t0)
 
+watchdog.stop()
 os.exit(0)

--- a/test/stopped.lua
+++ b/test/stopped.lua
@@ -6,6 +6,8 @@ local ffi = require('ffi')
 local clock = require('clock')
 local watchdog = require('watchdog')
 
+watchdog.stop()
+
 local t0 = clock.monotonic()
 watchdog.start(1)
 watchdog.stop()
@@ -18,5 +20,10 @@ ffi.C.sleep(2)
 
 local t1 = clock.monotonic()
 log.info("Still alive after %f sec", t1-t0)
+
+-- Attemt to stop watchdog twice
+watchdog.start(1)
+watchdog.stop()
+watchdog.stop()
 
 os.exit(0)


### PR DESCRIPTION
This patch fixes several problems.
The main problem is segfault when user calls watchdog.stop
before start or calls watchdog.stop twice after start.
To eliminate this simple checks was added.

Second problem - tests. Tarantool 2.x has new event loop politic -
all threads should be stopped before application will be terminated.
This led to stuck and abort - test was failed.

Also some stylistic changes is added.

Closes #6 