### PR TITLE
Introduce "enable_coredump" option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+- "enable_coredump" option.
+
 ## [1.0.2] - 2019-12-09
 ### Fixed
 - Fix segmentation fault when user called "stop" twice (gh-6)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 
 project(watchdog C)
 
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall -Wextra")
+
 if (APPLE)
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -undefined suppress -flat_namespace")
 endif(APPLE)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The fiber update period equals to 1/2 of the `timeout` parameter.
 The watchdog period is hardcoded to be 200ms.
 
 Whenever a problem with an update fiber occurs the watchdog thread
-performs `exit(6)`.
+performs `exit(6)` if coredump is disabled otherwise `abort()`.
 The problem may be caused by using blocking signals or
 by mistakes in other modules (e.g. `while true ... end`)
 
@@ -28,4 +28,5 @@ $ tarantoolctl rocks install watchdog
 ```lua
 local watchdog = require('watchdog')
 watchdog.start(1) -- timeout in seconds (double)
+watchdog.start(1, true) -- timeout in seconds (double) and coredump is enabled
 ```

--- a/test/abort.lua
+++ b/test/abort.lua
@@ -7,7 +7,17 @@ local clock = require('clock')
 local watchdog = require('watchdog')
 
 local t0 = clock.monotonic()
-watchdog.start(1)
+
+local enable_coredump = arg[1]
+if enable_coredump == 'true' then
+    enable_coredump = true
+elseif enable_coredump == 'false' then
+    enable_coredump = false
+else
+    enable_coredump = nil
+end
+
+watchdog.start(1, enable_coredump)
 
 ffi.cdef[[unsigned int sleep(unsigned int seconds);]]
 log.info("Running ffi.sleep(2)")

--- a/test/abort.sh
+++ b/test/abort.sh
@@ -1,5 +1,15 @@
 #!/bin/sh
 
 TESTDIR=$(dirname $0)
+${TESTDIR}/abort.lua false
+[ $? -eq 6 ]
+echo "Abort without coredump - OK"
+
+TESTDIR=$(dirname $0)
 ${TESTDIR}/abort.lua
 [ $? -eq 6 ]
+echo "Abort without coredump (by default) - OK"
+
+${TESTDIR}/abort.lua true
+[ $? -eq 134 ]  # 134 == 128 + 6
+echo "Abort with coredump - OK"

--- a/test/started.lua
+++ b/test/started.lua
@@ -16,4 +16,9 @@ local t1 = clock.monotonic()
 log.info("Still alive after %f sec", t1-t0)
 
 watchdog.stop()
+
+-- Start with enable_coredump option
+watchdog.start(1, true)
+watchdog.stop()
+
 os.exit(0)

--- a/test/stopped.lua
+++ b/test/stopped.lua
@@ -21,7 +21,7 @@ ffi.C.sleep(2)
 local t1 = clock.monotonic()
 log.info("Still alive after %f sec", t1-t0)
 
--- Attemt to stop watchdog twice
+-- Attempt to stop watchdog twice
 watchdog.start(1)
 watchdog.stop()
 watchdog.stop()


### PR DESCRIPTION
This patch introduces new option "enable_coredump" for watchdog:

```lua
watchdog.start(timeout)        -- default behaviour is false
watchdog.start(timeout, false) -- coredump is disabled
watchdog.start(timeout, true)  -- enable coredump if aborted
```

This option allows to choose strategy "exit(6)" - doesn't save
coredumps and abort that does it.