### PR TITLE
Add Docckerfile for fast developer rock build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-RUN curl -L https://tarantool.io/xLHQQc/release/2.6/installer.sh | bash
+RUN curl -L https://tarantool.io/release/2.6/installer.sh | bash
 RUN yum install -y tarantool tarantool-devel
 RUN yum install -y make gcc cmake curl libtool automake autoconf zip unzip
 
@@ -11,5 +11,5 @@ WORKDIR /watchdog
 ARG TAG=scm
 
 RUN tarantoolctl rocks new_version --tag $TAG \
-    && tarantoolctl rocks STATIC_BUILD=ON make watchdog-$TAG-1.rockspec \
+    && tarantoolctl rocks make watchdog-$TAG-1.rockspec \
     && tarantoolctl rocks pack watchdog $TAG

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM centos:7
+
+RUN curl -L https://tarantool.io/xLHQQc/release/2.6/installer.sh | bash
+RUN yum install -y tarantool tarantool-devel
+RUN yum install -y make gcc cmake curl libtool automake autoconf zip unzip
+
+ADD . /watchdog
+
+WORKDIR /watchdog
+
+ARG TAG=scm
+
+RUN tarantoolctl rocks new_version --tag $TAG \
+    && tarantoolctl rocks STATIC_BUILD=ON make watchdog-$TAG-1.rockspec \
+    && tarantoolctl rocks pack watchdog $TAG

--- a/README.md
+++ b/README.md
@@ -29,3 +29,14 @@ $ tarantoolctl rocks install watchdog
 local watchdog = require('watchdog')
 watchdog.start(1) -- timeout in seconds (double)
 ```
+
+## Build rockspec
+
+### centos 7.5
+
+``` bash
+docker build -t watchdog -f Dockerfile .
+docker create --name watchdog -it --rm watchdog
+docker cp watchdog:/watchdog/watchdog-scm-1.linux-x86_64.rock .
+docker rm -f watchdog
+```


### PR DESCRIPTION
Docker is convenient way to build some developer build with patches to test hypothesis on stage environments.