### PR TITLE
use on_shutdown trigger if available

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-20.04]
-        tarantool: ['1.10', '2.4', '2.5', '2.6', '2.7']
+        tarantool: ['1.10', '2.5', '2.6', '2.7', '2.8']
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
See for details https://github.com/tarantool/tarantool/commit/3010f024ea2378ff776ee773dc88cd53871b9a42

Why is it feature needed?

```
-- Without trigger
Tarantool Enterprise 2.7.1-0-g3ac498c9f-r391-macos
type 'help' for interactive help
tarantool> require('watchdog').start(2)
Watchdog started with timeout 2.0 sec (coredump disabled)
---
...
<Ctrl+C>
tarantool> Watchdog timeout 2.0 sec. Aborting
```

```
-- With trigger
Tarantool 2.8.0-316-gd2bd45109
type 'help' for interactive help
tarantool> require('watchdog').start(2)
Watchdog started with timeout 2.0 sec (coredump disabled)
---
...
<Ctrl+C>
Watchdog stopped
```