### PR TITLE
Fix graceful stop

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,13 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-20.04]
-        tarantool: ['1.10', '2.4', '2.5', '2.6', '2.7']
+        tarantool:
+          - '1.10'
+          - '2.4'
+          - '2.5'
+          - '2.6'
+          - '2.7'
+          - '2.8'
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v2

--- a/test/started.lua
+++ b/test/started.lua
@@ -19,6 +19,7 @@ watchdog.stop()
 
 -- Start with enable_coredump option
 watchdog.start(1, true)
-watchdog.stop()
 
+-- Exit tarantool without stopping watchdog explicitly.
+-- It shouldn't raise.
 os.exit(0)


### PR DESCRIPTION
Watchdog used the `atexit` function to stop gracefully. But its behavior was changed in Tarantool 2.1 (approximately) in favor of the `on_shutdown` trigger. Stopping watchdog gracefully only works with 1.10. 

This patch is the alternative for #16, but it uses Lua API `box.ctl.on_shutdown` instead of the C API, which is only available in Tarantool 2.8. It also includes a test.