### PR TITLE
Fix timeout precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.1.1] - 2021-06-04
+
+### Fixed
+
+- Depending of precise timings, the real timeout event may occur
+  from `timeout` to `1.25 * timeout` seconds. In the past it was
+  from `timeout/2` to `timeout`.
+
+- Fix graceful shutdown for Tarantool 2+.
+
 ## [1.1.0] - 2021-03-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ The watchdog module spawns a thread and continuously checks the value
 of an internal variable. The variable is updated periodically
 by a separate tarantool fiber.
 
-The fiber update period equals to 1/2 of the `timeout` parameter.
-The watchdog period is hardcoded to be 200ms.
+The watchdog observation period is hardcoded to be 200ms.
+The fiber update period equals to 1/4 of the `timeout` parameter.
+Depending of precise timings, the real timeout event may occur
+from `timeout` to `1.25 * timeout` seconds.
 
 Whenever a problem with an update fiber occurs the watchdog thread
 performs `exit(6)` if coredump is disabled otherwise `abort()`.


### PR DESCRIPTION
In the past, depending on precise timings, the real timeout event could occur from `timeout/2` to `timeout`.  Now the interval is from `timeout` to `1.25 * timeout` seconds.

This patch is also going to be tagged as 1.1.1 release